### PR TITLE
Fix the "git statu" bug (sed portability)

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -9,7 +9,7 @@ function init -a path --on-event init_cgitc
     # 1.  Strip out comments
     # 2.  Squeeze repeating spaces
     # 3.  Strip trailing whitespaces
-    set line (echo "$line" | cut -d '#' -f 1 | tr -s ' ' | sed 's/\s*$//')
+    set line (echo "$line" | cut -d '#' -f 1 | tr -s ' ' | sed 's/[[:space:]]*$//')
 
     # Skip empty lines
     if not [ "$line" ]; continue; end


### PR DESCRIPTION
[The `\s` is a GNU sed extension](http://stackoverflow.com/a/10422020/2079797) and is therefore not portable. On some systems (including OS X) `\s` is interpreted as a character `s` and therefore commands that end with `s` (such as `git status` or `git status -s`) will get the last letter stripped. For example, `gst` becomes `git statu`.

The issue can easily be avoided with the more portable `[:space:]` [character class](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap09.html#tag_09_03_05) that is part of the POSIX standard.
