### PR TITLE
Set cgitc_initialized after init

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -2,8 +2,6 @@ function init -a path --on-event init_cgitc
   # Skip if $cgitc_initialized is set
   if set -q cgitc_initialized; return; end
 
-  set -U cgitc_initialized
-
   printf 'Initializing \e[33mcgitc\e[0m ... '
   for line in (cat (dirname (status -f))/abbreviations)
     # 1.  Strip out comments
@@ -20,6 +18,8 @@ function init -a path --on-event init_cgitc
 
     abbr $key $value
   end
+
+  set -U cgitc_initialized
   echo 'Done'
 end
 


### PR DESCRIPTION
The initialization may fail for whatever reason, but since the universal variable `cgitc_initialized` is set before the init logic, it will be set anyway, removing the chance of retrying the init later.

(It also makes more sense to say "cgitc is initialized" _after_ it is actually initialized.)
