### PR TITLE
Add ggpush abbreviation

### DIFF
--- a/abbreviations
+++ b/abbreviations
@@ -46,8 +46,6 @@ gfo           git fetch origin
 gg            git gui citool
 gga           git gui citool --amend
 
-ggpur         ggu
-
 gignore       git update-index --assume-unchanged
 gignored      git ls-files -v | grep "^[[:lower:]]"
 

--- a/abbreviations
+++ b/abbreviations
@@ -46,6 +46,8 @@ gfo           git fetch origin
 gg            git gui citool
 gga           git gui citool --amend
 
+ggpush        git push origin HEAD
+
 gignore       git update-index --assume-unchanged
 gignored      git ls-files -v | grep "^[[:lower:]]"
 

--- a/init.fish
+++ b/init.fish
@@ -94,7 +94,6 @@ end
 # fi
 # }
 # compdef _git ggp=git-checkout
-# alias ggpush='git push origin $(git_current_branch)'
 # compdef _git ggpush=git-checkout
 # ggpnp() {
 # if [[ "$#" == 0 ]]; then

--- a/init.fish
+++ b/init.fish
@@ -110,6 +110,7 @@ end
 # git pull --rebase origin "${b:=$1}"
 # }
 # compdef _git ggu=git-checkout
+# alias ggpur='ggu'
 # compdef _git ggpur=git-checkout
 
 # alias git-svn-dcommit-push='git svn dcommit && git push github master:svntrunk'


### PR DESCRIPTION
`git push origin HEAD` pushes to current branch. See `man git-push`.

> git push origin HEAD
> 
> A handy way to push the current branch to the same name on the remote.

Also removed `ggpur` as `ggu` is unavailable.
