### PR TITLE
move abbreviations to before.init.fish and remove --on-event

### DIFF
--- a/before.init.fish
+++ b/before.init.fish
@@ -1,4 +1,6 @@
+if status -c
 # Abbreviations sorted in alphabetically
+echo "
 g             git
 
 ga            git add
@@ -122,3 +124,5 @@ glum          git pull upstream master
 gvt           git verify-tag
 
 gwch          git whatchanged -p --abbrev-commit --pretty=medium
+"
+end

--- a/init.fish
+++ b/init.fish
@@ -1,9 +1,7 @@
-function init -a path --on-event init_cgitc
-  # Skip if $cgitc_initialized is set
-  if set -q cgitc_initialized; return; end
-
+# Skip if $cgitc_initialized is set
+if not set -q cgitc_initialized
   printf 'Initializing \e[33mcgitc\e[0m ... '
-  for line in (cat (dirname (status -f))/abbreviations)
+  for line in (source (dirname (status -f))/*before.init.fish)
     # 1.  Strip out comments
     # 2.  Squeeze repeating spaces
     # 3.  Strip trailing whitespaces

--- a/uninstall.fish
+++ b/uninstall.fish
@@ -1,17 +1,15 @@
-function uninstall --on-event uninstall_cgitc
-  for line in (cat (dirname (status -f))/abbreviations)
-    # 1.  Strip out comments
-    # 2.  Squeeze repeating spaces
-    # 3.  Strip trailing whitespaces
-    set line (echo "$line" | cut -d '#' -f 1 | tr -s ' ' | sed 's/\s*$//')
+for line in (source (dirname (status -f))/*before.init.fish)
+  # 1.  Strip out comments
+  # 2.  Squeeze repeating spaces
+  # 3.  Strip trailing whitespaces
+  set line (echo "$line" | cut -d '#' -f 1 | tr -s ' ' | sed 's/\s*$//')
 
-    # Skip empty lines
-    if not [ "$line" ]; continue; end
+  # Skip empty lines
+  if not [ "$line" ]; continue; end
 
-    # Parse lines
-    set key (echo "$line" | cut -d ' ' -f 1)
+  # Parse lines
+  set key (echo "$line" | cut -d ' ' -f 1)
 
-    abbr --erase "$key"
-  end
-  set --erase -U cgitc_initialized
+  abbr --erase "$key"
 end
+set --erase -U cgitc_initialized


### PR DESCRIPTION
I'm sorry, can you review it again? I think, I have done right this time. It's necessary to be compatible with fisher #11 
