### PR TITLE
Add --set-upstream to ggpush abbreviation

### DIFF
--- a/abbreviations
+++ b/abbreviations
@@ -47,7 +47,7 @@ gfo           git fetch origin
 gg            git gui citool
 gga           git gui citool --amend
 
-ggpush        git push origin HEAD
+ggpush        git push --set-upstream origin HEAD
 
 gignore       git update-index --assume-unchanged
 gignored      git ls-files -v | grep "^[[:lower:]]"


### PR DESCRIPTION
`ggpush` is an abbreviation of `git push origin HEAD` which is "a handy way to push the current branch to the same name on the remote." (source: `man git-push`)

The `--set-upstream` option adds an upstream (tracking) reference, enabling future commands like `git push` work without any arguments. This fits nicely to the spirit of `ggpush`.