### PR TITLE
Add gcaa

### DIFF
--- a/abbreviations
+++ b/abbreviations
@@ -21,6 +21,7 @@ gc            git commit -v
 gc!           git commit -v --amend
 gca           git commit -v -a
 gca!          git commit -v -a --amend
+gcaa          git commit -v -a --amend
 gcan!         git commit -v -a -s --no-edit --amend
 gcam          git commit -a -m
 gcb           git checkout -b


### PR DESCRIPTION
`gcaa` is basically a synonym of `gca!`. But it's far easier to type, and it's a good unambiguous abbreviation.