### PR TITLE
newer versions of fish no longer support . to source files.

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -42,4 +42,4 @@ if [ "$cgitc_revision" != "$current_revision" ]
   set -U cgitc_revision "$current_revision"
   echo 'Done'
 end
-. (realpath (dirname (status -f)))/run.fish
+source (realpath (dirname (status -f)))/run.fish


### PR DESCRIPTION
It has been deprecated fish on 2.7.1 version.
```
Initializing cgitc ... Done
~/.config/chips/dist/cgitc/init.fish (line 45): The file '.' is not executable by this user
. (realpath (dirname (status -f)))/run.fish
^
from sourcing file ~/.config/chips/dist/cgitc/init.fish
	called on line 3 of file ~/.config/chips/build.fish

from sourcing file ~/.config/chips/build.fish
	called on line 59 of file ~/.config/fish/config.fish

from sourcing file ~/.config/fish/config.fish
	called during startup
```

http://fishshell.com/docs/current/commands.html#source

> _`.` (a single period) is an alias for the source command. **The use of . is deprecated in favour of source, and `.` will be removed in a future version of fish.**_

