### PR TITLE
Fish shell: Use abbr

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,5 +1,5 @@
 # Support fish < 2.2
-if printf '2.2.0\n%s' "$FISH_VERSION" | sort --check=silent --version-sort
+if printf '%s\n2.2.0' "$FISH_VERSION" | sort --check=silent --version-sort
   for line in (cat (dirname (status -f))/abbreviations)
     # 1.  Strip out comments
     # 2.  Squeeze repeating spaces
@@ -23,9 +23,7 @@ set -l current_revision (git -C (dirname (realpath (status -f))) rev-parse HEAD)
 if [ "$cgitc_revision" != "$current_revision" ]
   printf 'Initializing \x1b[33mcgitc\x1b[0m ... '
 
-  set -l cgitc_text
-
-  if printf '3.0.0\n%s' "$FISH_VERSION" | sort --check=silent --version-sort
+  if printf '%s\n3.0.0' "$FISH_VERSION" | sort --check=silent --version-sort
     # For 2.2.0 < fish < 3.0.0 use fish_user_abbreviations env. var
     set -l cgitc_text (
       for line in (cat (dirname (realpath (status -f)))/abbreviations)
@@ -44,7 +42,7 @@ if [ "$cgitc_revision" != "$current_revision" ]
     echo "set -gx fish_user_abbreviations \$fish_user_abbreviations $cgitc_text" > (realpath (dirname (status -f)))/run.fish
   else
     # For fish > 3.0.0 use abbr command
-    set cgitc_text (
+    set -l cgitc_text (
       for line in (cat (dirname (realpath (status -f)))/abbreviations)
         # 1.  Strip out comments
         # 2.  Squeeze repeating spaces
@@ -63,6 +61,7 @@ if [ "$cgitc_revision" != "$current_revision" ]
     )
     echo -s \n$cgitc_text > (realpath (dirname (status -f)))/run.fish
   end
+
   set -U cgitc_revision "$current_revision"
   echo 'Done'
 end

--- a/init.fish
+++ b/init.fish
@@ -32,12 +32,14 @@ if [ "$cgitc_revision" != "$current_revision" ]
       # Skip empty lines
       if not [ "$line" ]; continue; end
 
-      # Wrap with double quote
-      echo "\"$line\""
-    end | tr '\n' ' '
-  )
+      # Tokenize
+      set line (string split ' ' $line)
 
-  echo "set -gx fish_user_abbreviations \$fish_user_abbreviations $cgitc_text" > (realpath (dirname (status -f)))/run.fish
+      # Wrap with calling 'abbr'
+      echo "abbr --add --global -- $line[1] \"$line[2..-1]\""
+    end 
+  )
+  echo -s \n$cgitc_text > (realpath (dirname (status -f)))/run.fish
 
   set -U cgitc_revision "$current_revision"
   echo 'Done'

--- a/init.fish
+++ b/init.fish
@@ -1,5 +1,5 @@
 # Support fish < 2.2
-switch "$FISH_VERSION"; case 2.1.2 2.1.1 2.1.0 2.0.0
+if printf '2.2.0\n%s' "$FISH_VERSION" | sort --check=silent --version-sort
   for line in (cat (dirname (status -f))/abbreviations)
     # 1.  Strip out comments
     # 2.  Squeeze repeating spaces
@@ -22,25 +22,47 @@ end
 set -l current_revision (git -C (dirname (realpath (status -f))) rev-parse HEAD)
 if [ "$cgitc_revision" != "$current_revision" ]
   printf 'Initializing \x1b[33mcgitc\x1b[0m ... '
-  set -l cgitc_text (
-    for line in (cat (dirname (realpath (status -f)))/abbreviations)
-      # 1.  Strip out comments
-      # 2.  Squeeze repeating spaces
-      # 3.  Strip trailing whitespaces
-      set line (echo "$line" | cut -d '#' -f 1 | tr -s ' ' | sed 's/[[:space:]]*$//')
 
-      # Skip empty lines
-      if not [ "$line" ]; continue; end
+  set -l cgitc_text
 
-      # Tokenize
-      set line (string split ' ' $line)
+  if printf '3.0.0\n%s' "$FISH_VERSION" | sort --check=silent --version-sort
+    # For 2.2.0 < fish < 3.0.0 use fish_user_abbreviations env. var
+    set -l cgitc_text (
+      for line in (cat (dirname (realpath (status -f)))/abbreviations)
+        # 1.  Strip out comments
+        # 2.  Squeeze repeating spaces
+        # 3.  Strip trailing whitespaces
+        set line (echo "$line" | cut -d '#' -f 1 | tr -s ' ' | sed 's/[[:space:]]*$//')
 
-      # Wrap with calling 'abbr'
-      echo "abbr --add --global -- $line[1] \"$line[2..-1]\""
-    end 
-  )
-  echo -s \n$cgitc_text > (realpath (dirname (status -f)))/run.fish
+        # Skip empty lines
+        if not [ "$line" ]; continue; end
 
+        # Wrap with double quote
+        echo "\"$line\""
+      end | tr '\n' ' '
+    )
+    echo "set -gx fish_user_abbreviations \$fish_user_abbreviations $cgitc_text" > (realpath (dirname (status -f)))/run.fish
+  else
+    # For fish > 3.0.0 use abbr command
+    set cgitc_text (
+      for line in (cat (dirname (realpath (status -f)))/abbreviations)
+        # 1.  Strip out comments
+        # 2.  Squeeze repeating spaces
+        # 3.  Strip trailing whitespaces
+        set line (echo "$line" | cut -d '#' -f 1 | tr -s ' ' | sed 's/[[:space:]]*$//')
+
+        # Skip empty lines
+        if not [ "$line" ]; continue; end
+
+        # Tokenize
+        set line (string split ' ' $line)
+
+        # Wrap with calling 'abbr'
+        echo "abbr --add --global -- $line[1] \"$line[2..-1]\""
+      end
+    )
+    echo -s \n$cgitc_text > (realpath (dirname (status -f)))/run.fish
+  end
   set -U cgitc_revision "$current_revision"
   echo 'Done'
 end


### PR DESCRIPTION
With the release of fish 3.0.0 the variable `fish_user_abbreviations` was removed so I have rewritten it to use the `abbr --add` command instead which was introduced in 2.2.0 and hence should be backward compatible. Only I am not sure when was introduced  `string split` that might break backward compatibility, but I have already burned the whole day on this, so I am too lazy to check.