### PR TITLE
Support git switch and restore shortcut

### DIFF
--- a/abbreviations
+++ b/abbreviations
@@ -198,3 +198,4 @@ grhhd                git reset --hard HEAD
 grhh1                git reset --hard HEAD~1
 gsta                 git stash
 gc-                  git checkout -
+gw                   git switch

--- a/abbreviations
+++ b/abbreviations
@@ -199,3 +199,4 @@ grhh1                git reset --hard HEAD~1
 gsta                 git stash
 gc-                  git checkout -
 gw                   git switch
+gr                   git restore


### PR DESCRIPTION
> [Highlights from Git 2.23 - The GitHub Blog](https://github.blog/2019-08-16-highlights-from-git-2-23/)

아시다시피 Git 2.23 버전부터 `checkout` 명령어를 브랜치 변경과 복구로 분리한 `switch` 와 `restore` 명령어가 추가되었습니다.