### PR TITLE
Add git worktree abbreviations

### DIFF
--- a/abbreviations
+++ b/abbreviations
@@ -181,6 +181,11 @@ glum                 git pull upstream master
 
 gwch                 git whatchanged -p --abbrev-commit --pretty=medium
 #gwip                 git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign -m "--wip-- [skip ci]"
+gwt                  git worktree
+gwta                 git worktree add
+gwtls                git worktree list
+gwtmv                git worktree move
+gwtrm                git worktree remove
 
 #git_current_branch
 


### PR DESCRIPTION
Add 5 new abbreviations for git worktree commands:

- `gwt` - git worktree
- `gwta` - git worktree add
- `gwtls` - git worktree list
- `gwtmv` - git worktree move
- `gwtrm` - git worktree remove

These abbreviations are based on [ohmyzsh's git plugin 418~422 lines](https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/git/git.plugin.zsh#L418-L422).